### PR TITLE
Alma

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+*.gem
+*.rbc
+/.config
+/coverage/
+/specs/coverage
+/InstalledFiles
+/pkg/
+/spec/reports/
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalisation:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+   t.test_files = FileList['specs/*_spec.rb']
+ end
+
+task default: :test

--- a/door.rb
+++ b/door.rb
@@ -1,10 +1,11 @@
+# @todo rescue for ArgumentErrors
+
 module Dungeon
   class Door
 
     attr_accessor :lock_status, :inscription, :closed
 
     attr_reader :key_id
-
 
     # initialize with door closed, locked/unlocked, and with/without inscription
     def initialize(lock_status, key_id, inscription = nil)
@@ -15,9 +16,9 @@ module Dungeon
       @lock_status = lock_status #true for locked
 
       @lock_status == true ? init_state = "locked" : init_state = "unlocked"
-      puts "Here stands an ancient and sturdy door. It appears to be #{ init_state }."
+      puts "Here stands an ancient and sturdy door. It is closed #{ @lock_status == true ? "and" : "but" } appears to be #{ init_state }."
       if @inscription != nil
-        puts "The inscription over the door reads: '#{ @inscription }''"
+        puts "The inscription on the door reads: '#{ @inscription }''"
       end
     end
 
@@ -71,10 +72,24 @@ module Dungeon
       raise ArgumentError.new("The door must be closed to use the lock") if closed? == false
       raise ArgumentError.new("The key does not match the door key hole") if @key_id != key
 
-
       @lock_status == true ? @lock_status = false : @lock_status = true
 
       return @lock_status
     end
   end
 end
+
+# door = Dungeon::Door.new(true, "GOODKEY")
+# # door.open_door
+# # door.turn_key("BADKEY")
+# door.turn_key("GOODKEY")
+# puts door.inspect_door
+# door.open_door
+# puts door.inspect_door
+# door.close_door
+# door.turn_key("GOODKEY")
+# puts door.inspect_door
+# door.inscribe_door("Awesome door!")
+# puts door.inspect_door
+# door.inscribe_door("Alma was here")
+# puts door.inspect_door

--- a/door.rb
+++ b/door.rb
@@ -21,7 +21,7 @@ module Dungeon
       end
     end
 
-    def inspect
+    def inspect_door
       if @inscription == nil #no inscription
         if @closed == true
           return "Here stands an ancient and sturdy door. It is closed #{ @lock_status == true ? "and" : "but" } appears to be #{ @lock_status == true ? "locked" : "unlocked" }."
@@ -34,10 +34,16 @@ module Dungeon
         else # open door
           return "Here stands an ancient and sturdy door wide open. The door has a sign with the inscription: #{ @inscription }"
         end
+      end #if-inscription
+    end #def
 
+    def inscribe_door(inscription)
+      if @inscription == nil
+        return @inscription = inscription
+      else
+        raise ArgumentError.new("The door is already inscribed with the words: '#{ @inscription }' and it cannot be changed.")
       end
-
-    end
+    end #def
 
 
 

--- a/door.rb
+++ b/door.rb
@@ -1,7 +1,4 @@
 # @todo rescue for ArgumentErrors
-# @todo discuss if Errors are ArgumentErrors?
-# @todo check for argument type in initialize
-# @todo commit message for refactor
 
 module Dungeon
   class Door
@@ -12,6 +9,10 @@ module Dungeon
 
     # initialize with door closed, locked/unlocked, and with/without inscription
     def initialize(lock_status, key_id, inscription = nil)
+
+      raise ArgumentError.new("Parameter lock_status must be true or false") unless lock_status == true || lock_status == false
+      raise ArgumentError.new("Parameter key_id must be of type String") unless key_id.class == String || key_id.class == NilClass
+      raise ArgumentError.new("Parameter inscription must be nil or of String type") unless inscription.class == NilClass || inscription.class == String
 
       @closed = true
       @inscription = inscription
@@ -82,17 +83,17 @@ module Dungeon
   end
 end
 
-door = Dungeon::Door.new(true, "GOODKEY")
+# door = Dungeon::Door.new(true, "GOODKEY")
+# # door.open_door
+# # door.turn_key("BADKEY")
+# door.turn_key("GOODKEY")
+# puts door.inspect_door
 # door.open_door
-# door.turn_key("BADKEY")
-door.turn_key("GOODKEY")
-puts door.inspect_door
-door.open_door
-puts door.inspect_door
-door.close_door
-door.turn_key("GOODKEY")
-puts door.inspect_door
-door.inscribe_door("Awesome door!")
-puts door.inspect_door
-door.inscribe_door("Alma was here")
-puts door.inspect_door
+# puts door.inspect_door
+# door.close_door
+# door.turn_key("GOODKEY")
+# puts door.inspect_door
+# door.inscribe_door("Awesome door!")
+# puts door.inspect_door
+# door.inscribe_door("Alma was here")
+# puts door.inspect_door

--- a/door.rb
+++ b/door.rb
@@ -3,18 +3,38 @@ module Dungeon
 
     attr_accessor :lock_status, :inscription, :closed
 
+    attr_reader :key_id
+
 
     # initialize with door closed, locked/unlocked, and with/without inscription
-    def initialize(lock_status, inscription = nil)
+    def initialize(lock_status, key_id, inscription = nil)
 
       @closed = true
-      @lock_status = lock_status
       @inscription = inscription
+      @key = key_id #key identifier for lockable doors, key_id == nil means lock_status cannot change
+      @lock_status = lock_status #true for locked
 
       @lock_status == true ? init_state = "locked" : init_state = "unlocked"
-      puts "Here stands an ancient and #{ init_state } sturdy door"
+      puts "Here stands an ancient and sturdy door. It appears to be #{ init_state }."
       if @inscription != nil
         puts "The inscription over the door reads: '#{ @inscription }''"
+      end
+    end
+
+    def inspect
+      if @inscription == nil #no inscription
+        if @closed == true
+          return "Here stands an ancient and sturdy door. It is closed #{ @lock_status == true ? "and" : "but" } appears to be #{ @lock_status == true ? "locked" : "unlocked" }."
+        else # open door
+          return "Here stands an ancient and sturdy door wide open."
+        end
+      else #inscription exists
+        if @closed == true
+          return "Here stands an ancient and sturdy door. It is closed #{ @lock_status == true ? "and" : "but" } appears to be #{ @lock_status == true ? "locked" : "unlocked" }. The door has a sign with the inscription: #{ @inscription }"
+        else # open door
+          return "Here stands an ancient and sturdy door wide open. The door has a sign with the inscription: #{ @inscription }"
+        end
+
       end
 
     end

--- a/door.rb
+++ b/door.rb
@@ -11,7 +11,7 @@ module Dungeon
 
       @closed = true
       @inscription = inscription
-      @key = key_id #key identifier for lockable doors, key_id == nil means lock_status cannot change
+      @key_id = key_id #key identifier for lockable doors, key_id == nil means lock_status cannot change
       @lock_status = lock_status #true for locked
 
       @lock_status == true ? init_state = "locked" : init_state = "unlocked"
@@ -45,9 +45,36 @@ module Dungeon
       end
     end #def
 
+    def open_door
+      raise ArgumentError.new("This door is already open") if @closed == false
+      raise ArgumentError.new("This door is locked. Use a key to unlock it") if @lock_status == true
+
+      return @closed = false
+    end
+
+    def close_door
+      raise ArgumentError.new("This door is already closed") if @closed == true
+
+      return @closed = true
+    end
+
+    def closed?
+      return @closed
+    end
+
+    def locked?
+      return @lock_status
+    end
+
+    def turn_key(key = nil)
+      raise ArgumentError.new("This door has no lock") if @key_id == nil
+      raise ArgumentError.new("The door must be closed to use the lock") if closed? == false
+      raise ArgumentError.new("The key does not match the door key hole") if @key_id != key
 
 
+      @lock_status == true ? @lock_status = false : @lock_status = true
 
-
+      return @lock_status
+    end
   end
 end

--- a/door.rb
+++ b/door.rb
@@ -1,0 +1,27 @@
+module Dungeon
+  class Door
+
+    attr_accessor :lock_status, :inscription, :closed
+
+
+    # initialize with door closed, locked/unlocked, and with/without inscription
+    def initialize(lock_status, inscription = nil)
+
+      @closed = true
+      @lock_status = lock_status
+      @inscription = inscription
+
+      @lock_status == true ? init_state = "locked" : init_state = "unlocked"
+      puts "Here stands an ancient and #{ init_state } sturdy door"
+      if @inscription != nil
+        puts "The inscription over the door reads: '#{ @inscription }''"
+      end
+
+    end
+
+
+
+
+
+  end
+end

--- a/door.rb
+++ b/door.rb
@@ -1,4 +1,7 @@
 # @todo rescue for ArgumentErrors
+# @todo discuss if Errors are ArgumentErrors?
+# @todo check for argument type in initialize
+# @todo commit message for refactor
 
 module Dungeon
   class Door
@@ -12,11 +15,11 @@ module Dungeon
 
       @closed = true
       @inscription = inscription
-      @key_id = key_id #key identifier for lockable doors, key_id == nil means lock_status cannot change
+      @key_id = key_id #key identifier for lockable doors, key_id == nil means there is no lock on the door object
       @lock_status = lock_status #true for locked
 
-      @lock_status == true ? init_state = "locked" : init_state = "unlocked"
-      puts "Here stands an ancient and sturdy door. It is closed #{ @lock_status == true ? "and" : "but" } appears to be #{ init_state }."
+      locked? ? init_state = "locked" : init_state = "unlocked"
+      puts "Here stands an ancient and sturdy door. It is closed #{ locked? ? "and" : "but" } appears to be #{ init_state }."
       if @inscription != nil
         puts "The inscription on the door reads: '#{ @inscription }''"
       end
@@ -24,37 +27,37 @@ module Dungeon
 
     def inspect_door
       if @inscription == nil #no inscription
-        if @closed == true
-          return "Here stands an ancient and sturdy door. It is closed #{ @lock_status == true ? "and" : "but" } appears to be #{ @lock_status == true ? "locked" : "unlocked" }."
+        if closed?
+          return "Here stands an ancient and sturdy door. It is closed #{ locked? ? "and" : "but" } appears to be #{ locked? ? "locked" : "unlocked" }."
         else # open door
           return "Here stands an ancient and sturdy door wide open."
         end
       else #inscription exists
-        if @closed == true
-          return "Here stands an ancient and sturdy door. It is closed #{ @lock_status == true ? "and" : "but" } appears to be #{ @lock_status == true ? "locked" : "unlocked" }. The door has a sign with the inscription: #{ @inscription }"
+        if closed?
+          return "Here stands an ancient and sturdy door. It is closed #{ locked? ? "and" : "but" } appears to be #{ locked? ? "locked" : "unlocked" }. The door has a sign with the inscription: #{ @inscription }"
         else # open door
           return "Here stands an ancient and sturdy door wide open. The door has a sign with the inscription: #{ @inscription }"
         end
       end #if-inscription
     end #def
 
-    def inscribe_door(inscription)
+    def inscribe_door(words)
       if @inscription == nil
-        return @inscription = inscription
+        return @inscription = words.to_s
       else
         raise ArgumentError.new("The door is already inscribed with the words: '#{ @inscription }' and it cannot be changed.")
       end
     end #def
 
     def open_door
-      raise ArgumentError.new("This door is already open") if @closed == false
-      raise ArgumentError.new("This door is locked. Use a key to unlock it") if @lock_status == true
+      raise ArgumentError.new("This door is already open") unless closed?
+      raise ArgumentError.new("This door is locked. Use a key to unlock it") if locked?
 
       return @closed = false
     end
 
     def close_door
-      raise ArgumentError.new("This door is already closed") if @closed == true
+      raise ArgumentError.new("This door is already closed") if closed?
 
       return @closed = true
     end
@@ -69,27 +72,27 @@ module Dungeon
 
     def turn_key(key = nil)
       raise ArgumentError.new("This door has no lock") if @key_id == nil
-      raise ArgumentError.new("The door must be closed to use the lock") if closed? == false
+      raise ArgumentError.new("The door must be closed to use the lock") unless closed?
       raise ArgumentError.new("The key does not match the door key hole") if @key_id != key
 
-      @lock_status == true ? @lock_status = false : @lock_status = true
+      locked? ? @lock_status = false : @lock_status = true
 
       return @lock_status
     end
   end
 end
 
-# door = Dungeon::Door.new(true, "GOODKEY")
-# # door.open_door
-# # door.turn_key("BADKEY")
-# door.turn_key("GOODKEY")
-# puts door.inspect_door
+door = Dungeon::Door.new(true, "GOODKEY")
 # door.open_door
-# puts door.inspect_door
-# door.close_door
-# door.turn_key("GOODKEY")
-# puts door.inspect_door
-# door.inscribe_door("Awesome door!")
-# puts door.inspect_door
-# door.inscribe_door("Alma was here")
-# puts door.inspect_door
+# door.turn_key("BADKEY")
+door.turn_key("GOODKEY")
+puts door.inspect_door
+door.open_door
+puts door.inspect_door
+door.close_door
+door.turn_key("GOODKEY")
+puts door.inspect_door
+door.inscribe_door("Awesome door!")
+puts door.inspect_door
+door.inscribe_door("Alma was here")
+puts door.inspect_door

--- a/specs/door_spec.rb
+++ b/specs/door_spec.rb
@@ -38,10 +38,11 @@ module Dungeon
       end
 
       it "should be possible to inspect an open door without/with an inscription for its state" do
-        skip # @todo until method to open_door available
-        wide_open_door_no_inscript = unlocked_door_no_inscript.open_door
+        wide_open_door_no_inscript = unlocked_door_no_inscript
+        wide_open_door_no_inscript.open_door
         wide_open_door_no_inscript.inspect_door.must_equal("Here stands an ancient and sturdy door wide open.")
-        wide_open_door_with_inscript = unlocked_door_with_inscript.open_door
+        wide_open_door_with_inscript = unlocked_door_with_inscript
+        wide_open_door_with_inscript.open_door
         wide_open_door_with_inscript.inspect_door.must_equal("Here stands an ancient and sturdy door wide open. The door has a sign with the inscription: Push to open")
       end
 

--- a/specs/door_spec.rb
+++ b/specs/door_spec.rb
@@ -3,7 +3,8 @@ module Dungeon
   describe Door do
 
     describe "#initialize" do
-      let(:door) { Door.new(:lock_status, :key_id) }
+      let(:door) { Door.new(true, "ABC123") }
+      let(:odd_door) { Door.new("LOCKED", :key, :inscription) }
 
       it "can create an object of Door" do
         door.must_be_instance_of(Door)
@@ -17,6 +18,12 @@ module Dungeon
 
       it "should be a closed door that initializes" do
         door.closed.must_equal(true)
+      end
+
+      it "should check parameters are the correct type" do
+        proc{odd_door.lock_status}.must_raise(ArgumentError)
+        proc{odd_door.key_id.class}.must_raise(ArgumentError)
+        proc{odd_door.inscription.class}.must_raise(ArgumentError)
       end
 
     end #init

--- a/specs/door_spec.rb
+++ b/specs/door_spec.rb
@@ -1,0 +1,72 @@
+require_relative 'spec_helper'
+
+
+
+# @todo would like to see more negative tests, what-if
+
+module Dungeon
+  describe Door do
+
+    describe "#initialize" do
+      let(:door) { Door.new(:lock_status) }
+
+      it "can create an object of Door" do
+        door.must_be_instance_of(Door)
+      end
+
+      it "should respond to parameters of door status" do
+        door.must_respond_to(:lock_status)
+        door.must_respond_to(:inscription)
+      end
+
+    it "should be a closed door that initializes" do
+      door.closed.must_equal(true)
+    end
+
+    end #init
+
+    describe "#the rest" do
+
+
+
+      it "should display an inscription, if there is one written" do
+        skip
+      end
+
+      it "should be possible to open, when closed and unlocked" do
+        skip
+      end
+
+      it "should be possible to close a door, if open" do
+        skip
+      end
+
+      it "should be possible to lock or unlock, if closed, by switching state" do
+        skip
+      end
+
+      it "should be possible to inscribe the door only once" do
+        skip
+      end
+
+      it "should be possible to inspect a door for its state of open/closed" do
+        skip
+      end
+
+      it "should be possible to inspect a door for its state of locked/unlocked" do
+        skip
+      end
+
+      it "should be possible to inspect a door to read the inscription" do
+        skip
+      end
+
+      it "should give a warning message if the door is used in the wrong way" do
+        # check for warning for opening a locked door without first unlocked
+        # check for warning for changing the inscription when there is already once
+        # check for warning for closing/opening an already closed/open door
+        skip
+      end
+    end #method
+  end #Door
+end #mod

--- a/specs/door_spec.rb
+++ b/specs/door_spec.rb
@@ -8,7 +8,7 @@ module Dungeon
   describe Door do
 
     describe "#initialize" do
-      let(:door) { Door.new(:lock_status) }
+      let(:door) { Door.new(:lock_status, :key_id) }
 
       it "can create an object of Door" do
         door.must_be_instance_of(Door)
@@ -16,23 +16,54 @@ module Dungeon
 
       it "should respond to parameters of door status" do
         door.must_respond_to(:lock_status)
+        door.must_respond_to(:key_id)
         door.must_respond_to(:inscription)
       end
 
-    it "should be a closed door that initializes" do
-      door.closed.must_equal(true)
-    end
+      it "should be a closed door that initializes" do
+        door.closed.must_equal(true)
+      end
 
     end #init
 
-    describe "#the rest" do
+    describe "#inspect" do
+      let(:unlocked_door_no_inscript) { Door.new(false, nil) }
+      let(:locked_door_no_inscript) { Door.new(true, "ABC123") }
+      let(:unlocked_door_with_inscript) { Door.new(false, nil, "Push to open") }
+      let(:locked_door_with_inscript) { Door.new(true, "ABC123", "Use key to open") }
 
+      it "should be possible to inspect a closed door without an inscription for its state of locked/unlocked" do
+        unlocked_door_no_inscript.inspect.must_equal("Here stands an ancient and sturdy door. It is closed but appears to be unlocked.")
+        locked_door_no_inscript.inspect.must_equal("Here stands an ancient and sturdy door. It is closed and appears to be locked.")
+      end
 
+      it "should be possible to inspect a closed door with an inscription for its state of locked/unlocked" do
+        unlocked_door_with_inscript.inspect.must_equal("Here stands an ancient and sturdy door. It is closed but appears to be unlocked. The door has a sign with the inscription: Push to open")
+        locked_door_with_inscript.inspect.must_equal("Here stands an ancient and sturdy door. It is closed and appears to be locked. The door has a sign with the inscription: Use key to open")
+      end
 
+      it "should be possible to inspect an open door without/with an inscription for its state" do
+        skip # @todo until method to open_door available
+        wide_open_door_no_inscript = unlocked_door_no_inscript.open_door
+        wide_open_door_no_inscript.inspect.must_equal("Here stands an ancient and sturdy door wide open.")
+        wide_open_door_with_inscript = unlocked_door_with_inscript.open_door
+        wide_open_door_with_inscript.inspect.musmust_equal("Here stands an ancient and sturdy door wide open. The door has a sign with the inscription: Push to open")
+      end
+
+    end #inspect
+
+    describe "#inscription" do
       it "should display an inscription, if there is one written" do
         skip
       end
 
+      it "should be possible to inscribe the door only once" do
+        skip
+      end
+
+    end #inscription
+
+    describe "open" do
       it "should be possible to open, when closed and unlocked" do
         skip
       end
@@ -41,27 +72,27 @@ module Dungeon
         skip
       end
 
-      it "should be possible to lock or unlock, if closed, by switching state" do
+    end #open
+
+    describe "#turn_key" do
+
+      it "if closed, should be possible to lock or unlocked, by switching state" do
         skip
       end
 
-      it "should be possible to inscribe the door only once" do
-        skip
-      end
+    end
 
-      it "should be possible to inspect a door for its state of open/closed" do
-        skip
-      end
+    describe "#closed?" do
 
-      it "should be possible to inspect a door for its state of locked/unlocked" do
-        skip
-      end
+    end
 
-      it "should be possible to inspect a door to read the inscription" do
-        skip
-      end
+    describe "locked?" do
+
+
+
 
       it "should give a warning message if the door is used in the wrong way" do
+        # missing key?
         # check for warning for opening a locked door without first unlocked
         # check for warning for changing the inscription when there is already once
         # check for warning for closing/opening an already closed/open door

--- a/specs/door_spec.rb
+++ b/specs/door_spec.rb
@@ -33,32 +33,41 @@ module Dungeon
       let(:locked_door_with_inscript) { Door.new(true, "ABC123", "Use key to open") }
 
       it "should be possible to inspect a closed door without an inscription for its state of locked/unlocked" do
-        unlocked_door_no_inscript.inspect.must_equal("Here stands an ancient and sturdy door. It is closed but appears to be unlocked.")
-        locked_door_no_inscript.inspect.must_equal("Here stands an ancient and sturdy door. It is closed and appears to be locked.")
+        unlocked_door_no_inscript.inspect_door.must_equal("Here stands an ancient and sturdy door. It is closed but appears to be unlocked.")
+        locked_door_no_inscript.inspect_door.must_equal("Here stands an ancient and sturdy door. It is closed and appears to be locked.")
       end
 
       it "should be possible to inspect a closed door with an inscription for its state of locked/unlocked" do
-        unlocked_door_with_inscript.inspect.must_equal("Here stands an ancient and sturdy door. It is closed but appears to be unlocked. The door has a sign with the inscription: Push to open")
-        locked_door_with_inscript.inspect.must_equal("Here stands an ancient and sturdy door. It is closed and appears to be locked. The door has a sign with the inscription: Use key to open")
+        unlocked_door_with_inscript.inspect_door.must_equal("Here stands an ancient and sturdy door. It is closed but appears to be unlocked. The door has a sign with the inscription: Push to open")
+        locked_door_with_inscript.inspect_door.must_equal("Here stands an ancient and sturdy door. It is closed and appears to be locked. The door has a sign with the inscription: Use key to open")
       end
 
       it "should be possible to inspect an open door without/with an inscription for its state" do
         skip # @todo until method to open_door available
         wide_open_door_no_inscript = unlocked_door_no_inscript.open_door
-        wide_open_door_no_inscript.inspect.must_equal("Here stands an ancient and sturdy door wide open.")
+        wide_open_door_no_inscript.inspect_door.must_equal("Here stands an ancient and sturdy door wide open.")
         wide_open_door_with_inscript = unlocked_door_with_inscript.open_door
-        wide_open_door_with_inscript.inspect.musmust_equal("Here stands an ancient and sturdy door wide open. The door has a sign with the inscription: Push to open")
+        wide_open_door_with_inscript.inspect_door.must_equal("Here stands an ancient and sturdy door wide open. The door has a sign with the inscription: Push to open")
       end
 
     end #inspect
 
-    describe "#inscription" do
-      it "should display an inscription, if there is one written" do
-        skip
+    describe "#inscribe_door" do
+      before(:each) do
+        @unlocked_door_no_inscript = Door.new(false, nil)
       end
 
-      it "should be possible to inscribe the door only once" do
-        skip
+
+      it "should set a value to inscription" do
+        door = @unlocked_door_no_inscript
+        door.inscribe_door("Come through here for danger")
+        door.inscription.must_equal("Come through here for danger")
+      end
+
+      it "should not be possible to change the inscription once set" do
+        door = @unlocked_door_no_inscript
+        door.inscribe_door("Come through here for danger")
+        proc{door.inscribe_door("Free candy this way")}.must_raise(ArgumentError)
       end
 
     end #inscription

--- a/specs/door_spec.rb
+++ b/specs/door_spec.rb
@@ -1,9 +1,4 @@
 require_relative 'spec_helper'
-
-
-
-# @todo would like to see more negative tests, what-if
-
 module Dungeon
   describe Door do
 
@@ -26,7 +21,7 @@ module Dungeon
 
     end #init
 
-    describe "#inspect" do
+    describe "#inspect_door" do
       let(:unlocked_door_no_inscript) { Door.new(false, nil) }
       let(:locked_door_no_inscript) { Door.new(true, "ABC123") }
       let(:unlocked_door_with_inscript) { Door.new(false, nil, "Push to open") }
@@ -72,40 +67,101 @@ module Dungeon
 
     end #inscription
 
-    describe "open" do
-      it "should be possible to open, when closed and unlocked" do
-        skip
+    describe "#open_door" do
+      before(:each) do
+        @unlocked_door = Door.new(false, nil)
+      end
+      let(:locked_door) { Door.new(true, "123ABC") }
+
+
+      it "should be possible to open the door" do
+        @unlocked_door.open_door
+        @unlocked_door.closed.must_equal(false)
       end
 
-      it "should be possible to close a door, if open" do
-        skip
+      it "should not be possible to open a locked door" do
+        proc{locked_door.open_door}.must_raise(ArgumentError)
       end
 
+      it "should not be possible to open an already open door" do
+        door = @unlocked_door
+        door.open_door
+        proc{door.open_door}.must_raise(ArgumentError)
+      end
     end #open
 
-    describe "#turn_key" do
+    describe "#close_door" do
+      let(:door) { Door.new(false, nil) }
 
-      it "if closed, should be possible to lock or unlocked, by switching state" do
-        skip
+      it "should be possible to close an open door" do
+        door.open_door
+        door.close_door
+        door.closed.must_equal(true)
       end
 
-    end
+      it "should not be possible to close a door when it is already closed" do
+        proc{door.close_door}.must_raise(ArgumentError)
+      end
+    end #closed
 
     describe "#closed?" do
+      before(:each) do
+        @door = Door.new(false, nil)
+      end
 
-    end
+      it "should return true if the door is closed" do
+        @door.closed?.must_equal(true)
+      end
 
-    describe "locked?" do
+      it "should return false if the door is open" do
+        @door.open_door
+        @door.closed?.must_equal(false)
+      end
+    end #closed?
 
+    describe "#locked?" do
+      before(:each) do
+        @locked_door = Door.new(true, "ABC123")
+        @unlocked_door = Door.new(false, nil)
+      end
 
+      it "should return true if the door is locked" do
+        @locked_door.locked?.must_equal(true)
+      end
 
+      it "should return false if the door is unlocked" do
+        @unlocked_door.locked?.must_equal(false)
+      end
+    end #locked?
 
-      it "should give a warning message if the door is used in the wrong way" do
-        # missing key?
-        # check for warning for opening a locked door without first unlocked
-        # check for warning for changing the inscription when there is already once
-        # check for warning for closing/opening an already closed/open door
-        skip
+    describe "#turn_key" do
+      before(:each) do
+        @locked_door = Door.new(true, "ABC123")
+        @unlocked_door = Door.new(false, "ABC123")
+        @door_without_lock = Door.new(false,nil)
+      end
+
+      it "should be possible to turn the key in the lock to switch lock state" do
+        @locked_door.turn_key("ABC123")
+        @locked_door.locked?.must_equal(false)
+
+        @unlocked_door.turn_key("ABC123")
+        @unlocked_door.locked?.must_equal(true)
+      end
+
+      it "can only have a key turning if it has a key assigned/if it has a lock" do
+        proc{@door_without_lock.turn_key}.must_raise(ArgumentError)
+        proc{@door_without_lock.turn_key}.must_raise(ArgumentError)
+      end
+
+      it "must fail to lock/unlock unless key identifier match input key" do
+        proc{@locked_door.turn_key("BADKEY")}.must_raise(ArgumentError)
+      end
+
+      it "should only be possible to unlock/lock a closed door" do
+        door = @unlocked_door
+        door.open_door
+        proc{door.turn_key("ABC123")}.must_raise(ArgumentError)
       end
     end #method
   end #Door

--- a/specs/spec_helper.rb
+++ b/specs/spec_helper.rb
@@ -1,0 +1,10 @@
+require 'simplecov'
+SimpleCov.start
+require 'minitest'
+require 'minitest/spec'
+require "minitest/autorun"
+require "minitest/reporters"
+require 'minitest/pride'
+
+require_relative '../far_mar'
+Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new

--- a/specs/spec_helper.rb
+++ b/specs/spec_helper.rb
@@ -6,5 +6,5 @@ require "minitest/autorun"
 require "minitest/reporters"
 require 'minitest/pride'
 
-require_relative '../far_mar'
+require_relative '../door'
 Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new


### PR DESCRIPTION
Dungeon door complete.  It asks for arguments for lock/unlock, key identifier (set at initialization to nil if no lock) and a choice inscription (defaults to nil if not set on initialization).

Door cannot be locked/unlocked without the correct key available. Wizards' spells, thieves lock picks, and warriors' brute force are not implemented. Also not implemented are magic barrier doors, traps, voice activation, etc.

Rescues for raised errors on the @todo list.
